### PR TITLE
Rewrite InvalidDirectiveError messages and export actual GraphQL Input and Field types in their directive definitions

### DIFF
--- a/docs/directives.md
+++ b/docs/directives.md
@@ -1,0 +1,50 @@
+---
+title: Directives
+---
+
+TypeGraphQL provides basic support for [GraphQL directives](https://www.apollographql.com/docs/graphql-tools/schema-directives/).
+
+> A directive is an identifier preceded by a @ character, optionally followed by a list of named arguments, which can appear after almost any form of syntax in the GraphQL query or schema languages.
+
+Here's a modified example from the GraphQL draft specification that illustrates several of these possibilities:
+
+```graphql
+directive @deprecated(
+  reason: String = "No longer supported"
+) on OBJECT | FIELD_DEFINITION
+
+@deprecated(reason: "Use `NewType`.")
+type Foo {
+  field: String
+}
+
+type Bar {
+  newField: String
+  oldField: String @deprecated(reason: "Use `newField`.")
+}
+```
+
+With type-graphql, you can add directives on fields and objects with `@Directive(nameOrDeclaration: string)` as in this example:
+
+```typescript
+import { Directive, Field, ObjectType } from "type-graphql";
+
+@ObjectType()
+@Directive("deprecated")
+class Foo {
+  @Field()
+  field: string;
+}
+
+@ObjectType()
+class Bar {
+  @Field()
+  newField;
+
+  @Field()
+  @Directive('@deprecated(reason: "Use `newField`")')
+  oldField;
+}
+```
+
+Please note that `@Directive` can only contain a single GraphQL directive name or declaration.

--- a/src/errors/InvalidDirectiveError.ts
+++ b/src/errors/InvalidDirectiveError.ts
@@ -1,9 +1,8 @@
 import { DirectiveMetadata } from "../metadata/definitions/directive-metadata";
 
 export class InvalidDirectiveError extends Error {
-  constructor(msg: string, directive: DirectiveMetadata) {
-    super(`${msg} "${directive.nameOrDefinition}"`);
-
+  constructor(msg: string) {
+    super(msg);
     Object.setPrototypeOf(this, new.target.prototype);
   }
 }

--- a/src/errors/InvalidDirectiveError.ts
+++ b/src/errors/InvalidDirectiveError.ts
@@ -1,5 +1,3 @@
-import { DirectiveMetadata } from "../metadata/definitions/directive-metadata";
-
 export class InvalidDirectiveError extends Error {
   constructor(msg: string) {
     super(msg);

--- a/src/metadata/definitions/directive-metadata.ts
+++ b/src/metadata/definitions/directive-metadata.ts
@@ -7,6 +7,7 @@ export interface DirectiveClassMetadata {
   target: Function;
   directive: DirectiveMetadata;
 }
+
 export interface DirectiveFieldMetadata {
   target: Function;
   field: string;

--- a/src/schema/schema-generator.ts
+++ b/src/schema/schema-generator.ts
@@ -764,8 +764,7 @@ export abstract class SchemaGenerator {
 
     if (nameOrDefinition === "") {
       throw new InvalidDirectiveError(
-        "You can pass only one directive to the @Directive decorator at a time for",
-        directive,
+        "Please pass at-least one directive name or definition to the @Directive decorator",
       );
     }
 
@@ -802,13 +801,14 @@ export abstract class SchemaGenerator {
         });
       }
     } catch (err) {
-      throw new InvalidDirectiveError("Error parsing directive", directive);
+      throw new InvalidDirectiveError(
+        `Error parsing directive definition "${directive.nameOrDefinition}"`,
+      );
     }
 
     if (directives.length !== 1) {
       throw new InvalidDirectiveError(
-        "You can pass only one directive to the @Directive decorator at a time for",
-        directive,
+        `Please pass only one directive name or definition at a time to the @Directive decorator "${directive.nameOrDefinition}"`,
       );
     }
 

--- a/src/utils/buildTypeDefsAndResolvers.ts
+++ b/src/utils/buildTypeDefsAndResolvers.ts
@@ -1,4 +1,5 @@
 import { printSchema } from "graphql";
+
 import { BuildSchemaOptions, buildSchema } from "./buildSchema";
 import { createResolversMap } from "./createResolversMap";
 

--- a/tests/functional/directives.ts
+++ b/tests/functional/directives.ts
@@ -423,7 +423,7 @@ describe("Directives", () => {
         expect(err).toBeInstanceOf(InvalidDirectiveError);
         const error: InvalidDirectiveError = err;
         expect(error.message).toContain(
-          'You can pass only one directive to the @Directive decorator at a time for "@upper @append"',
+          'Please pass only one directive name or definition at a time to the @Directive decorator "@upper @append"',
         );
       }
     });
@@ -445,7 +445,9 @@ describe("Directives", () => {
       } catch (err) {
         expect(err).toBeInstanceOf(InvalidDirectiveError);
         const error: InvalidDirectiveError = err;
-        expect(error.message).toContain('Error parsing directive "@invalid(@directive)"');
+        expect(error.message).toContain(
+          'Error parsing directive definition "@invalid(@directive)"',
+        );
       }
     });
 
@@ -467,7 +469,7 @@ describe("Directives", () => {
         expect(err).toBeInstanceOf(InvalidDirectiveError);
         const error: InvalidDirectiveError = err;
         expect(error.message).toContain(
-          'You can pass only one directive to the @Directive decorator at a time for ""',
+          "Please pass at-least one directive name or definition to the @Directive decorator",
         );
       }
     });


### PR DESCRIPTION
As suggested by @MichalLytek in https://github.com/MichalLytek/type-graphql/pull/369